### PR TITLE
Fix CursorLine, CursorColumn and ColorColumn

### DIFF
--- a/colors/luna-term.vim
+++ b/colors/luna-term.vim
@@ -143,10 +143,10 @@ hi PmenuSel     ctermfg=23   ctermbg=15   cterm=NONE
 hi PmenuSbar    ctermfg=235  ctermbg=235  cterm=NONE
 hi PmenuThumb   ctermfg=235  ctermbg=235  cterm=NONE
 hi MatchParen   ctermfg=16   ctermbg=203  cterm=NONE
-hi CursorLine   ctermbg=236  ctermbg=NONE cterm=NONE
+hi CursorLine   ctermfg=NONE ctermbg=236  cterm=NONE
 hi CursorLineNr ctermfg=117  ctermbg=NONE cterm=NONE
-hi CursorColumn ctermbg=236  ctermbg=NONE cterm=NONE
-hi ColorColumn  ctermbg=237  ctermbg=NONE cterm=NONE
+hi CursorColumn ctermfg=NONE ctermbg=236  cterm=NONE
+hi ColorColumn  ctermfg=NONE ctermbg=237  cterm=NONE
 hi WildMenu     ctermfg=23   ctermbg=231  cterm=NONE
 hi SignColumn   ctermfg=NONE ctermbg=234  cterm=NONE
 "


### PR DESCRIPTION
The bg colors for CursorLine, CursorColumn and ColorColumn are in the first column (which the rest of the file uses as fg) and then the second column sets them to none, so they never show.
